### PR TITLE
Fix devices shocking repeatedly

### DIFF
--- a/code/datums/wires/airlock.dm
+++ b/code/datums/wires/airlock.dm
@@ -32,10 +32,6 @@
 	if(!..())
 		return FALSE
 	var/obj/machinery/door/airlock/A = holder
-	if(!istype(user, /mob/living/silicon))
-		if(A.isElectrified())
-			if(A.shock(user, 100))
-				return FALSE
 	if(!A.p_open)
 		return FALSE
 	return TRUE

--- a/code/datums/wires/smartfridge.dm
+++ b/code/datums/wires/smartfridge.dm
@@ -20,10 +20,6 @@
 	if(!..())
 		return FALSE
 	var/obj/machinery/smartfridge/S = holder
-	if(!istype(user, /mob/living/silicon))
-		if(S.seconds_electrified)
-			if(S.shock(user, 100))
-				return FALSE
 	if(S.panel_open)
 		return TRUE
 	return FALSE

--- a/code/datums/wires/suit_storage_unit.dm
+++ b/code/datums/wires/suit_storage_unit.dm
@@ -15,10 +15,6 @@
 	if(!..())
 		return FALSE
 	var/obj/machinery/suit_cycler/S = holder
-	if(!istype(user, /mob/living/silicon))
-		if(S.electrified)
-			if(S.shock(user, 100))
-				return FALSE
 	if(S.panel_open)
 		return TRUE
 	return FALSE

--- a/code/datums/wires/vending.dm
+++ b/code/datums/wires/vending.dm
@@ -20,10 +20,6 @@
 	if(!..())
 		return FALSE
 	var/obj/machinery/vending/V = holder
-	if(!istype(user, /mob/living/silicon))
-		if(V.seconds_electrified)
-			if(V.shock(user, 100))
-				return FALSE
 	if(V.panel_open)
 		return TRUE
 	return FALSE


### PR DESCRIPTION
A fix for https://github.com/Aurorastation/Aurora.3/issues/18219

Should resolve the issue, actual .shock() calls are happening when appropriate. 
Could not do proper testing due to a lack of experience with the game and tooling, but no issues were encountered.

If desired, .shock() calls can be added to /datum/wires/<DEVICE>/on_pulse(wire) 

